### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -1,10 +1,10 @@
-KiotlogSN       KEYWORD1
-MkrGsm          KEYWORD1
-FonaGsm         KEYWORD1
-Aead            KEYWORD1
+KiotlogSN	KEYWORD1
+MkrGsm	KEYWORD1
+FonaGsm	KEYWORD1
+Aead	KEYWORD1
 
-start           KEYWORD2
-sendPayload     KEYWORD2
-begin           KEYWORD2
-authEncrypt     KEYWORD2
-updateStatus    KEYWORD2
+start	KEYWORD2
+sendPayload	KEYWORD2
+begin	KEYWORD2
+authEncrypt	KEYWORD2
+updateStatus	KEYWORD2


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords